### PR TITLE
Definable Python Binary

### DIFF
--- a/ebs-recover-and-replace/Makefile
+++ b/ebs-recover-and-replace/Makefile
@@ -1,6 +1,12 @@
 artifact_name       := ebs_recover_and_replace
 version             := $(shell grep "version" pyproject.toml | awk '{print $3}' | cut -d\" -f2)
 
+ifdef PYTHON_BIN
+python_bin := $(PYTHON_BIN)
+else
+python_bin := python3
+endif
+
 .PHONY: all
 all: build
 
@@ -11,7 +17,7 @@ clean:
 
 .PHONY: build
 build:
-	python3 -m build
+	$(python_bin) -m build
 	cp ./dist/$(artifact_name)-$(version).tar.gz ./$(artifact_name)-$(version).tar.gz
 
 .PHONY: dist

--- a/ec2-tag-query/Makefile
+++ b/ec2-tag-query/Makefile
@@ -1,6 +1,12 @@
 artifact_name       := ec2_tag_query
 version             := $(shell grep "version" pyproject.toml | awk '{print $3}' | cut -d\" -f2)
 
+ifdef PYTHON_BIN
+python_bin := $(PYTHON_BIN)
+else
+python_bin := python3
+endif
+
 .PHONY: all
 all: build
 
@@ -11,7 +17,7 @@ clean:
 
 .PHONY: build
 build:
-	python3 -m build
+	$(python_bin) -m build
 	cp ./dist/$(artifact_name)-$(version).tar.gz ./$(artifact_name)-$(version).tar.gz
 
 .PHONY: dist


### PR DESCRIPTION
Update Makefiles to allow the python binary to be defined via an environment variable. Defaults to `python3`