### PR TITLE
Concourse Webhook Validator - Support Input File

### DIFF
--- a/concourse-webhook-validator/src/concourse_webhook_validator/__init__.py
+++ b/concourse-webhook-validator/src/concourse_webhook_validator/__init__.py
@@ -7,11 +7,13 @@ import yaml
 """
 Defaults
 """
-WEBHOOK_REGEX = '^[a-zA-Z0-9]*$'
+WEBHOOK_REGEX = "^[a-zA-Z0-9]*$"
 
 """
 Classes & Functions
 """
+
+
 class colours:
     blue = "\033[1;34m"
     red = "\033[1;31m"
@@ -37,48 +39,42 @@ def format_output(message="", style="info") -> None:
 
 def read_pipelines_list_from_file(pipeline_file) -> list:
     try:
-        with open(pipeline_file, 'r') as file:
+        with open(pipeline_file, "r") as file:
             pipelines_list = [line.rstrip() for line in file]
     except OSError as err:
         format_output(
             f"Unable to open/read the provided file: {colours.bold}{pipeline_file}{colours.end}",
-            "error"
+            "error",
         )
         sys.exit(1)
     except:
         format_output(
             f"Unexpected error opening file: {colours.bold}{pipeline_file}{colours.end}",
-            "error"
+            "error",
         )
         sys.exit(1)
 
     return pipelines_list
 
 
-def load_pipeline_config(pipeline_config_file_path:str) -> object:
+def load_pipeline_config(pipeline_config_file_path: str) -> object:
     """
     The file must exist before we load it. Once loaded the
     entire python object is returned.
     """
     if os.path.isfile(pipeline_config_file_path):
-        with open(pipeline_config_file_path, 'r') as file:
+        with open(pipeline_config_file_path, "r") as file:
             pipeline_config = yaml.safe_load(file)
 
         return pipeline_config
-    
+
     else:
-        format_output(
-            "The specified pipeline file could not be found",
-            "error"
-        )
-        format_output(
-            f"{pipeline_config_file_path}",
-            "error"
-        )
+        format_output("The specified pipeline file could not be found", "error")
+        format_output(f"{pipeline_config_file_path}", "error")
         sys.exit(1)
 
 
-def validate_pipeline_config(pipeline_config:object) -> int:
+def validate_pipeline_config(pipeline_config: object) -> int:
     """
     For a pipeline to be considered 'valid' it must contain both
     'jobs' and resources' keys.
@@ -86,55 +82,45 @@ def validate_pipeline_config(pipeline_config:object) -> int:
     1: Invalid
     """
     validation_error = 0
-    if 'jobs' not in pipeline_config:
-        format_output(
-            "No 'jobs' found in pipeline configuration",
-            "warn"
-        )
+    if "jobs" not in pipeline_config:
+        format_output("No 'jobs' found in pipeline configuration", "warn")
         validation_error = 1
-    
-    if 'resources' not in pipeline_config:
-        format_output(
-            "No 'resources' found in pipeline configuration",
-            "warn"
-        )
+
+    if "resources" not in pipeline_config:
+        format_output("No 'resources' found in pipeline configuration", "warn")
         validation_error = 1
-    
+
     return validation_error
 
 
-def parse_pipeline_resources(pipeline_config:object, webhook_dict:dict) -> None:
-    for resource in pipeline_config['resources']:
-        resource_name = resource['name']
-        if 'webhook_token' in resource:
-            if resource['webhook_token'] is not None:
-                resource_webhook_token = resource['webhook_token']
-                webhook_dict[resource_name] = {'rwt': resource_webhook_token}
-    
+def parse_pipeline_resources(pipeline_config: object, webhook_dict: dict) -> None:
+    for resource in pipeline_config["resources"]:
+        resource_name = resource["name"]
+        if "webhook_token" in resource:
+            if resource["webhook_token"] is not None:
+                resource_webhook_token = resource["webhook_token"]
+                webhook_dict[resource_name] = {"rwt": resource_webhook_token}
 
-def parse_pipeline_jobs(pipeline_config:object, webhook_dict:dict) -> None:
-    for job in pipeline_config['jobs']:
-        if job['name'] == 'create-webhooks':
-            for create_plan in job['plan']:
-                if 'webhook_token' in create_plan['params']:
-                    create_webhook_token = create_plan['params']['webhook_token']
-                    webhook_dict[create_plan['params']['resource_name']].update(
-                        {
-                            'cwt': create_webhook_token
-                        }
+
+def parse_pipeline_jobs(pipeline_config: object, webhook_dict: dict) -> None:
+    for job in pipeline_config["jobs"]:
+        if job["name"] == "create-webhooks":
+            for create_plan in job["plan"]:
+                if "webhook_token" in create_plan["params"]:
+                    create_webhook_token = create_plan["params"]["webhook_token"]
+                    webhook_dict[create_plan["params"]["resource_name"]].update(
+                        {"cwt": create_webhook_token}
                     )
-        if job['name'] == 'delete-webhooks':
-            for delete_plan in job['plan']:
-                if 'webhook_token' in delete_plan['params']:
-                    delete_webhook_token = delete_plan['params']['webhook_token']
-                    webhook_dict[delete_plan['params']['resource_name']].update(
-                        {
-                            'dwt': delete_webhook_token
-                        }
+        if job["name"] == "delete-webhooks":
+            for delete_plan in job["plan"]:
+                if "webhook_token" in delete_plan["params"]:
+                    delete_webhook_token = delete_plan["params"]["webhook_token"]
+                    webhook_dict[delete_plan["params"]["resource_name"]].update(
+                        {"dwt": delete_webhook_token}
                     )
 
 
-def validate_webhooks(webhooks_dict:dict) -> None:
+def validate_webhooks(webhooks_dict: dict) -> None:
     for resource in webhooks_dict:
         resource_webhooks = webhooks_dict[resource]
         """
@@ -142,19 +128,11 @@ def validate_webhooks(webhooks_dict:dict) -> None:
         0: Valid
         1: Invalid
         """
-        valid_webhook = re.search(WEBHOOK_REGEX, resource_webhooks['rwt'])
+        valid_webhook = re.search(WEBHOOK_REGEX, resource_webhooks["rwt"])
         if valid_webhook:
-            webhooks_dict[resource].update(
-                {
-                    'rwv': 0
-                }
-            )
+            webhooks_dict[resource].update({"rwv": 0})
         else:
-            webhooks_dict[resource].update(
-                {
-                    'rwv': 1
-                }
-            )
+            webhooks_dict[resource].update({"rwv": 1})
 
         """
         The webhook tokens specified in 'create-webhooks' and 'delete-webhooks'
@@ -163,48 +141,24 @@ def validate_webhooks(webhooks_dict:dict) -> None:
         1: No match
         2: No webhook job found
         """
-        if 'cwt' in resource_webhooks:
-            if resource_webhooks['cwt'] == resource_webhooks['rwt']:
-                webhooks_dict[resource].update(
-                    {
-                        'cwv': 0
-                    }
-                )
+        if "cwt" in resource_webhooks:
+            if resource_webhooks["cwt"] == resource_webhooks["rwt"]:
+                webhooks_dict[resource].update({"cwv": 0})
             else:
-                webhooks_dict[resource].update(
-                    {
-                        'cwv': 1
-                    }
-                )
+                webhooks_dict[resource].update({"cwv": 1})
         else:
-            webhooks_dict[resource].update(
-                {
-                    'cwv': 2
-                }
-            )
+            webhooks_dict[resource].update({"cwv": 2})
 
-        if 'dwt' in resource_webhooks:
-            if resource_webhooks['dwt'] == resource_webhooks['rwt']:
-                webhooks_dict[resource].update(
-                    {
-                        'dwv': 0
-                    }
-                )
+        if "dwt" in resource_webhooks:
+            if resource_webhooks["dwt"] == resource_webhooks["rwt"]:
+                webhooks_dict[resource].update({"dwv": 0})
             else:
-                webhooks_dict[resource].update(
-                    {
-                        'dwv': 1
-                    }
-                )
+                webhooks_dict[resource].update({"dwv": 1})
         else:
-            webhooks_dict[resource].update(
-                {
-                    'dwv': 2
-                }
-            )
+            webhooks_dict[resource].update({"dwv": 2})
 
 
-def display_results(webhooks_dict:dict) -> int:
+def display_results(webhooks_dict: dict) -> int:
     format_output(
         f"Webhooked resources discovered: {colours.bold}{len(webhooks_dict)}{colours.end}\n"
     )
@@ -226,15 +180,16 @@ def display_results(webhooks_dict:dict) -> int:
     Table header includes some padding to allow the text to be properly centered
     without being cramped agaist the '|' separators.
     """
-    print(f"{resource_name_text.ljust(int(resource_name_length + 1))}|" +
-            f"{resource_token_valid_text.center(int(len(resource_token_valid_text) + 2))}|" +
-            f"{create_token_matches_text.center(int(len(create_token_matches_text) + 2))}|" +
-            f"{delete_token_matches_text.center(int(len(delete_token_matches_text) + 2))}\n" +
-            f"{'-' * int(resource_name_length + 1)}|" +
-            f"{'-' * int(len(resource_token_valid_text) + 2)}|" +
-            f"{'-' * int(len(create_token_matches_text) + 2)}|" +
-            f"{'-' * int(len(delete_token_matches_text) + 2)}")
-    
+    print(
+        f"{resource_name_text.ljust(int(resource_name_length + 1))}|"
+        + f"{resource_token_valid_text.center(int(len(resource_token_valid_text) + 2))}|"
+        + f"{create_token_matches_text.center(int(len(create_token_matches_text) + 2))}|"
+        + f"{delete_token_matches_text.center(int(len(delete_token_matches_text) + 2))}\n"
+        + f"{'-' * int(resource_name_length + 1)}|"
+        + f"{'-' * int(len(resource_token_valid_text) + 2)}|"
+        + f"{'-' * int(len(create_token_matches_text) + 2)}|"
+        + f"{'-' * int(len(delete_token_matches_text) + 2)}"
+    )
 
     """
     Loop through and build the tabular output and track whether any
@@ -247,72 +202,72 @@ def display_results(webhooks_dict:dict) -> int:
         0: Valid token
         1: Invalid token
         """
-        if webhooks_dict[resource]['rwv'] == 0:
-            resource_webhook_valid = '✅'
+        if webhooks_dict[resource]["rwv"] == 0:
+            resource_webhook_valid = "✅"
         else:
-            resource_webhook_valid = '❌'
+            resource_webhook_valid = "❌"
             resource_validation_failed = 1
-            resource_failed_reasons.append(f"'{resource}' webhook token contains non-alphanumeric characters")
+            resource_failed_reasons.append(
+                f"'{resource}' webhook token contains non-alphanumeric characters"
+            )
 
         """
         0: Match
         1: No match
         2: No webhook job found
         """
-        if webhooks_dict[resource]['cwv'] == 0:
-            create_webhook_valid = '✅'
-        elif webhooks_dict[resource]['cwv'] == 1:
-            create_webhook_valid = '❌'
+        if webhooks_dict[resource]["cwv"] == 0:
+            create_webhook_valid = "✅"
+        elif webhooks_dict[resource]["cwv"] == 1:
+            create_webhook_valid = "❌"
             resource_validation_failed = 1
-            resource_failed_reasons.append(f"'create-webhooks' job '{resource}' has a different token to the resource")
+            resource_failed_reasons.append(
+                f"'create-webhooks' job '{resource}' has a different token to the resource"
+            )
         else:
-            create_webhook_valid = '❓'
+            create_webhook_valid = "❓"
             resource_validation_failed = 1
-            resource_failed_reasons.append(f"'{resource}' missing 'create-webhooks' job or webhook token parameter not set")
+            resource_failed_reasons.append(
+                f"'{resource}' missing 'create-webhooks' job or webhook token parameter not set"
+            )
 
-        if webhooks_dict[resource]['dwv'] == 0:
-            delete_webhook_valid = '✅'
-        elif webhooks_dict[resource]['dwv'] == 1:
-            delete_webhook_valid = '❌'
+        if webhooks_dict[resource]["dwv"] == 0:
+            delete_webhook_valid = "✅"
+        elif webhooks_dict[resource]["dwv"] == 1:
+            delete_webhook_valid = "❌"
             resource_validation_failed = 1
-            resource_failed_reasons.append(f"'delete-webhooks' job '{resource}' has a different token to the resource")
+            resource_failed_reasons.append(
+                f"'delete-webhooks' job '{resource}' has a different token to the resource"
+            )
         else:
-            delete_webhook_valid = '❓'
+            delete_webhook_valid = "❓"
             resource_validation_failed = 1
-            resource_failed_reasons.append(f"'{resource}' missing 'delete-webhooks' job or webhook token parameter not set")
-        
-        print(f"{resource.ljust(int(resource_name_length) + 1)}|" +
-                f" {resource_webhook_valid.center(int(len(resource_token_valid_text)))}|" +
-                f" {create_webhook_valid.center(int(len(create_token_matches_text)))}|" +
-                f"{delete_webhook_valid.center(int(len(delete_token_matches_text)))}")
-    
+            resource_failed_reasons.append(
+                f"'{resource}' missing 'delete-webhooks' job or webhook token parameter not set"
+            )
+
+        print(
+            f"{resource.ljust(int(resource_name_length) + 1)}|"
+            + f" {resource_webhook_valid.center(int(len(resource_token_valid_text)))}|"
+            + f" {create_webhook_valid.center(int(len(create_token_matches_text)))}|"
+            + f"{delete_webhook_valid.center(int(len(delete_token_matches_text)))}"
+        )
+
     if resource_validation_failed == 1:
         print()
         for reason in resource_failed_reasons:
-            format_output(
-                reason,
-                "warn"
-            )
-    
+            format_output(reason, "warn")
+
     return resource_validation_failed
 
 
 def print_validation_summary(validation_failure_list) -> None:
     print()
-    print("-" * 80
-          + "\nValidation results summary\n"
-          + "-" * 80
-    )
+    print("-" * 80 + "\nValidation results summary\n" + "-" * 80)
     if len(validation_failure_list) > 0:
-        format_output(
-            "The following pipelines had validation failures",
-            "error"
-        )
+        format_output("The following pipelines had validation failures", "error")
         for failed_pipeline in validation_failure_list:
-            format_output(
-                f"{colours.bold}{failed_pipeline}{colours.end}",
-                "error"
-            )
+            format_output(f"{colours.bold}{failed_pipeline}{colours.end}", "error")
         sys.exit(1)
     else:
         format_output(
@@ -322,40 +277,46 @@ def print_validation_summary(validation_failure_list) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Program arguments and options")
-    parser.add_argument('pipeline',
-                        default=None,
-                        help="The name of the pipeline configuration to load",
-                        nargs=1
-                        )
-    parser.add_argument('--list',
-                        action='store_true',
-                        help="Specifies that the provided input is a file containing a list of pipeline configurations, one per line")
-    parser.add_argument('--base-dir',
-                        default='',
-                        help="The base directory in which the pipeline configurations are stored",
-                        nargs=1)
-    parser.add_argument('--deployment',
-                        default='',
-                        help="The name of the Concourse deployment",
-                        nargs=1)
-    parser.add_argument('--team',
-                        default='',
-                        help="The team name that the pipeline is configured for",
-                        nargs=1)
+    parser.add_argument(
+        "pipeline",
+        default=None,
+        help="The name of the pipeline configuration to load",
+        nargs=1,
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Specifies that the provided input is a file containing a list of pipeline configurations, one per line",
+    )
+    parser.add_argument(
+        "--base-dir",
+        default="",
+        help="The base directory in which the pipeline configurations are stored",
+        nargs=1,
+    )
+    parser.add_argument(
+        "--deployment", default="", help="The name of the Concourse deployment", nargs=1
+    )
+    parser.add_argument(
+        "--team",
+        default="",
+        help="The team name that the pipeline is configured for",
+        nargs=1,
+    )
     args = parser.parse_args()
-    
+
     if len(args.base_dir) == 0:
-        pipeline_base_dir = ''
+        pipeline_base_dir = ""
     else:
         pipeline_base_dir = args.base_dir[0]
-    
+
     if len(args.deployment) == 0:
-        pipeline_deployment = ''
+        pipeline_deployment = ""
     else:
         pipeline_deployment = args.deployment[0]
-    
+
     if len(args.team) == 0:
-        pipeline_team = ''
+        pipeline_team = ""
     else:
         pipeline_team = args.team[0]
 
@@ -366,8 +327,10 @@ def main() -> None:
 
     validation_failure_list = []
     for pipeline in pipelines_list:
-        pipeline_file_path = os.path.join(pipeline_base_dir, pipeline_deployment, pipeline_team, pipeline)
-        pipeline_name_element_list = pipeline_file_path.rsplit('/', 1)
+        pipeline_file_path = os.path.join(
+            pipeline_base_dir, pipeline_deployment, pipeline_team, pipeline
+        )
+        pipeline_name_element_list = pipeline_file_path.rsplit("/", 1)
         pipeline_name = pipeline_name_element_list[len(pipeline_name_element_list) - 1]
 
         webhooks_dict = {}
@@ -383,24 +346,18 @@ def main() -> None:
                 validate_webhooks(webhooks_dict)
                 if display_results(webhooks_dict) == 0:
                     print()
-                    format_output(
-                        "Webhooks configuration check completed successfully"
-                    )
+                    format_output("Webhooks configuration check completed successfully")
                 else:
                     validation_failure_list.append(pipeline_name)
                     format_output(
-                        "Webhooks validation failures were encountered",
-                        "warn"
+                        "Webhooks validation failures were encountered", "warn"
                     )
             else:
-                format_output(
-                    "No webhooked resources found"
-                )
+                format_output("No webhooked resources found")
         else:
             validation_failure_list.append(pipeline_name)
             format_output(
-                "Pipeline does not appear to be a valid configuration",
-                "warn"
+                "Pipeline does not appear to be a valid configuration", "warn"
             )
 
     print_validation_summary(validation_failure_list)


### PR DESCRIPTION
Updates `concourse-webhook-validator` to add support for passing in a file that contains a list of pipelines to be validated
Added `--list` argument
Added supporting functions
Cleaned up output messaging for consistency
Added summary to final output
PEP-8 formatting pass via `black`